### PR TITLE
FileReader needs to be serializable.

### DIFF
--- a/vision_datasets/common/util.py
+++ b/vision_datasets/common/util.py
@@ -39,6 +39,13 @@ class MultiProcessZipFile:
             z.close()
         self.zipfiles = {}
 
+    def __getstate__(self):
+        return {'filename': self.filename}
+
+    def __setstate__(self, state):
+        self.filename = state['filename']
+        self.zipfiles = {}
+
 
 class FileReader:
     """Reader to support <zip_filename>@<entry_name> style filename."""


### PR DESCRIPTION
To spawn a training process including a dataloader, we need this FileReader object to be serializable.