### PR TITLE
Remove lambda functions from TorchDataset

### DIFF
--- a/tests/test_pytorch_dataset.py
+++ b/tests/test_pytorch_dataset.py
@@ -1,0 +1,36 @@
+import pickle
+import unittest
+from vision_datasets.pytorch import TorchDataset
+
+
+class FakeDatasetInfo:
+    @property
+    def dataset_info(self):
+        return None
+
+
+def _one_arg_method(x):
+    return x
+
+
+class TestPytorchDataset(unittest.TestCase):
+    def test_picklable(self):
+        dataset = TorchDataset(FakeDatasetInfo())
+        serialized = pickle.dumps(dataset)
+        new_dataset = pickle.loads(serialized)
+        self.assertIsInstance(new_dataset, TorchDataset)
+
+        dataset = TorchDataset(FakeDatasetInfo(), _one_arg_method)
+        serialized = pickle.dumps(dataset)
+        new_dataset = pickle.loads(serialized)
+        self.assertIsInstance(new_dataset, TorchDataset)
+
+        dataset = TorchDataset(FakeDatasetInfo())
+        dataset.transform = None
+        serialized = pickle.dumps(dataset)
+        new_dataset = pickle.loads(serialized)
+        self.assertIsInstance(new_dataset, TorchDataset)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vision_datasets/pytorch/dataset.py
+++ b/vision_datasets/pytorch/dataset.py
@@ -4,14 +4,26 @@ import torch
 from inspect import signature
 
 
+def _identity(*args):
+    return args
+
+
+class _ImageOnlyTransform:
+    def __init__(self, transform):
+        self._transform = transform
+
+    def __call__(self, image, boxes):
+        return self._transform(image), boxes
+
+
 class Dataset(torch.utils.data.Dataset, ABC):
     def __init__(self, transform=None):
         super().__init__()
 
         if not transform:
-            self._transform = lambda x, y: (x, y)
+            self._transform = _identity
         elif len(signature(transform).parameters) == 1:
-            self._transform = lambda x, y: (transform(x), y)
+            self._transform = _ImageOnlyTransform(transform)
         else:
             self._transform = transform
 
@@ -29,7 +41,7 @@ class Dataset(torch.utils.data.Dataset, ABC):
 
     @transform.setter
     def transform(self, val):
-        self._transform = val if val else lambda x, y: (x, y)
+        self._transform = val if val else _identity
 
     def close(self):
         """Release the resources allocated for this dataset."""


### PR DESCRIPTION
-pickle will fail to serialize the Dataset object if it contains a lambda function.