### PR TITLE
add (balanced) spawn manifest

### DIFF
--- a/tests/test_dataset_manifest.py
+++ b/tests/test_dataset_manifest.py
@@ -841,6 +841,71 @@ class TestSampleByCategories(unittest.TestCase):
         assert new_manifest.images[3].labels == [0, 1]
 
 
+class TestSpawn(unittest.TestCase):
+    def test_spawn_od_manifest(self):
+        images = [
+            ImageDataManifest(0, './0.jpg', 10, 10, []),
+            ImageDataManifest(1, './1.jpg', 10, 10, [[0, 1, 1, 2, 2], [1, 2, 2, 3, 3]]),
+            ImageDataManifest(2, './2.jpg', 10, 10, [[1, 1, 1, 2, 2]]),
+            ImageDataManifest(3, './3.jpg', 10, 10, [[1, 0, 0, 2, 2], [2, 1, 1, 2, 2], [3, 2, 2, 3, 3]]),
+        ]
+        dst_size = 120
+        manifest = DatasetManifest(images, ['a', 'b', 'c', 'd'], DatasetTypes.OD)
+        new_manifest = manifest.spawn(dst_size, balanced=False)
+        self.assertEqual(len(new_manifest), dst_size)
+
+        self.assertIsInstance(manifest.spawn(dst_size, balanced=True), DatasetManifest)
+
+    def test_spawn_ic_multilabel_manifest(self):
+        images = [
+            ImageDataManifest(0, './0.jpg', 10, 10, []),
+            ImageDataManifest(1, './1.jpg', 10, 10, [0, 1]),
+            ImageDataManifest(1, './1.jpg', 10, 10, [0, 1]),
+            ImageDataManifest(2, './2.jpg', 10, 10, [1]),
+        ]
+        dst_size = 120
+        manifest = DatasetManifest(images, ['a', 'b'], DatasetTypes.IC_MULTILABEL)
+        new_manifest = manifest.spawn(dst_size, balanced=False)
+        self.assertEqual(len(new_manifest), dst_size)
+
+        self.assertIsInstance(manifest.spawn(dst_size, balanced=True, weight_upper=1.2), DatasetManifest)
+
+    def test_spawn_ic_multiclass_manifest(self):
+        images = [
+            ImageDataManifest(0, './0.jpg', 10, 10, [0]),
+            ImageDataManifest(1, './1.jpg', 10, 10, [0]),
+            ImageDataManifest(1, './1.jpg', 10, 10, [2]),
+            ImageDataManifest(2, './2.jpg', 10, 10, [1]),
+        ]
+        manifest = DatasetManifest(images, ['a', 'b', 'c'], DatasetTypes.IC_MULTILABEL)
+        dst_size = 120
+        new_manifest = manifest.spawn(dst_size, balanced=False)
+        self.assertEqual(len(new_manifest), dst_size)
+
+        new_manifest = manifest.spawn(dst_size, random_seed=0, balanced=True, soft=False)
+        cnt = self.cnt_multiclass_labels(new_manifest)
+        self.assertEqual(cnt, [40, 40, 40])
+
+    def cnt_multiclass_labels(self, manifest):
+        n_images_by_classes = [0] * len(manifest.labelmap) if not manifest.is_multitask else [0] * sum([len(x) for x in manifest.labelmap.values()])
+        for im in manifest.images:
+            manifest._add_label_count(im.labels, n_images_by_classes)
+        return n_images_by_classes
+
+    def test_spawn_multitask_manifest(self):
+        manifest = DatasetManifest.create_multitask_manifest({
+            'task1': TestCases.get_manifest(DatasetTypes.IC_MULTICLASS, 0),
+            'task2': TestCases.get_manifest(DatasetTypes.IC_MULTICLASS, 1),
+            'task3': TestCases.get_manifest(DatasetTypes.IC_MULTILABEL, 1),
+            'task4': TestCases.get_manifest(DatasetTypes.OD, 2)
+        })
+        dst_size = 120
+        new_manifest = manifest.spawn(dst_size, balanced=False)
+        self.assertEqual(len(new_manifest), dst_size)
+
+        self.assertIsInstance(manifest.spawn(dst_size, balanced=True, weight_lower=0.9), DatasetManifest)
+
+
 class TestCocoGeneration(unittest.TestCase):
     def test_coco_generation(self):
         for data_type in [DatasetTypes.IC_MULTICLASS, DatasetTypes.IC_MULTILABEL, DatasetTypes.OD, DatasetTypes.IMCAP]:

--- a/vision_datasets/common/balanced_instance_weights_generator.py
+++ b/vision_datasets/common/balanced_instance_weights_generator.py
@@ -15,7 +15,7 @@ class BalancedInstanceWeightsGenerator(object):
     def generate(data_manifest, soft=True, weight_upper=5, weight_lower=0.2):
         assert data_manifest is not None
 
-        logging.info("Generating instance weights for dataset balancing.")
+        logger.info("Generating instance weights for dataset balancing.")
         image_tags = [BalancedInstanceWeightsGenerator._process_tags(x.labels) for x in data_manifest.images]
 
         class_wise_image_counter = Counter()
@@ -31,7 +31,7 @@ class BalancedInstanceWeightsGenerator(object):
 
         image_weights = [BalancedInstanceWeightsGenerator._get_instance_multiplier(tags, class_wise_multipliers, weight_upper, weight_lower) for tags in image_tags]
 
-        logging.info(f'instance weights: max {max(image_weights)}, min {min(image_weights)}, len {len(image_weights)}')
+        logger.info(f'instance weights: max {max(image_weights)}, min {min(image_weights)}, len {len(image_weights)}')
         return image_weights
 
     @staticmethod

--- a/vision_datasets/common/balanced_instance_weights_generator.py
+++ b/vision_datasets/common/balanced_instance_weights_generator.py
@@ -1,0 +1,63 @@
+"""Instance weights generator for DataManifest. Only works for classification, detection, multitask. Adapted from irispy:
+https://msazure.visualstudio.com/Cognitive%20Services/_git/API-CustomVision-Irispy?path=/irispy/datasets/balanced_instance_weights_generator.py&version=GBmaster&_a=contents
+"""
+
+import logging
+from collections import Counter
+
+import numpy
+
+logger = logging.getLogger(__name__)
+
+
+class BalancedInstanceWeightsGenerator(object):
+    NEG_CLASS_INDEX = -1
+
+    @staticmethod
+    def generate(data_manifest, soft=True, weight_upper=5, weight_lower=0.2):
+        assert data_manifest
+
+        logging.info("Generating instance weights for dataset balancing.")
+        image_tags = [BalancedInstanceWeightsGenerator._process_tags(x.labels) for x in data_manifest.images]
+
+        class_wise_image_counter = Counter()
+        for tags in image_tags:
+            class_wise_image_counter.update(tags)
+
+        mean_class_wise_image_tag_count = numpy.mean(list(class_wise_image_counter.values()))
+        class_wise_multipliers = {x: mean_class_wise_image_tag_count / class_wise_image_counter[x] for x in class_wise_image_counter}
+        if soft:
+            class_wise_multipliers = {x: numpy.sqrt(class_wise_multipliers[x]) for x in class_wise_multipliers}
+
+        class_wise_multipliers = {x: BalancedInstanceWeightsGenerator._scope_multiplier(class_wise_multipliers[x], weight_upper, weight_lower) for x in class_wise_multipliers}
+
+        image_weights = [BalancedInstanceWeightsGenerator._get_instance_multiplier(tags, class_wise_multipliers, weight_upper, weight_lower) for tags in image_tags]
+
+        logging.info(f'instance weights: max {max(image_weights)}, min {min(image_weights)}, len {len(image_weights)}')
+        return image_weights
+
+    @staticmethod
+    def _process_tags(tags):
+        if not tags:
+            return [BalancedInstanceWeightsGenerator.NEG_CLASS_INDEX]
+
+        if isinstance(tags, dict):
+            return list(set(f'{str(k)}_{str(v[0])}' for k, v in tags.items() if v[0] != -1))
+
+        if isinstance(tags, int):
+            return [tags]
+
+        if isinstance(tags[0], int):
+            return list(set(tags))
+
+        return list(set([x[0] for x in tags]))
+
+    @staticmethod
+    def _get_instance_multiplier(tags, class_wise_multipliers, weight_upper, weight_lower):
+        mul = numpy.prod([class_wise_multipliers[tag] for tag in tags])
+
+        return BalancedInstanceWeightsGenerator._scope_multiplier(mul, weight_upper, weight_lower)
+
+    @staticmethod
+    def _scope_multiplier(value, weight_upper, weight_lower):
+        return min(max(value, weight_lower), weight_upper)

--- a/vision_datasets/common/balanced_instance_weights_generator.py
+++ b/vision_datasets/common/balanced_instance_weights_generator.py
@@ -1,6 +1,4 @@
-"""Instance weights generator for DataManifest. Only works for classification, detection, multitask. Adapted from irispy:
-https://msazure.visualstudio.com/Cognitive%20Services/_git/API-CustomVision-Irispy?path=/irispy/datasets/balanced_instance_weights_generator.py&version=GBmaster&_a=contents
-"""
+"""Generate instance weights from DatasetManifest, which can be used for balancing the dataset by sampling instances based on the weights. Only works for classification, detection, multitask."""
 
 import logging
 from collections import Counter
@@ -15,7 +13,7 @@ class BalancedInstanceWeightsGenerator(object):
 
     @staticmethod
     def generate(data_manifest, soft=True, weight_upper=5, weight_lower=0.2):
-        assert data_manifest
+        assert data_manifest is not None
 
         logging.info("Generating instance weights for dataset balancing.")
         image_tags = [BalancedInstanceWeightsGenerator._process_tags(x.labels) for x in data_manifest.images]


### PR DESCRIPTION
Spawn data manifest to a larger desired size. The original data is reserved first to ensure each class has samples.
If `instance_weights` not provided, randomly over sample.
If provided, the spawned data obtains the `instance_weights`