### PR TITLE
Add support for zero-shot dataset which only contains categores section

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 from os import path
 
-VERSION = '0.2.28'
+VERSION = '0.2.29'
 
 # Get the long description from the README file
 here = path.abspath(path.dirname(__file__))

--- a/vision_datasets/resources/dataset_hub.py
+++ b/vision_datasets/resources/dataset_hub.py
@@ -105,7 +105,7 @@ class DatasetHub(object):
 
         for usage in usages:
             manifest_usage = DatasetManifest.create_dataset_manifest(dataset_info, usage, local_dir or container_sas)
-            if manifest_usage:
+            if manifest_usage is not None:
                 manifest = DatasetManifest.merge(manifest, manifest_usage) if manifest else manifest_usage
 
             if downloader_resources_usage:


### PR DESCRIPTION
The length of a dataset will be len(images) will will be zero for a dataset only containing categories, for those dataset to work, we need this check to only check if the manifest_usage is None, if the images is empty we can still return