### PR TITLE
reformat object grounding jsonl file format

### DIFF
--- a/vision_datasets/visual_object_grounding/operations.py
+++ b/vision_datasets/visual_object_grounding/operations.py
@@ -24,4 +24,6 @@ SplitFactory.direct_register(Split, _DATA_TYPE)
 @StandAloneImageListGeneratorFactory.register(_DATA_TYPE)
 class Text2ImageRetrievalStandAloneImageListGenerator(GenerateStandAloneImageListBase):
     def _generate_label(self, label: VisualObjectGroundingLabelManifest, image: ImageDataManifest, manifest: DatasetManifest) -> dict:
-        return {'question': label.question, 'answer': label.answer, 'groundings': label.label_data['groundings']}
+        return {'question': label.question,
+                'answer': label.answer,
+                'grounding_metadata': {'groundings': label.label_data['groundings'], 'gt_answer': label.answer, 'size': [image.width, image.height]}}


### PR DESCRIPTION
This PR re-format the jsonl format for object grounding task, this is to forward the image size and gt to the evaluator.

Image size is for converting the relative coordinates returned by API to absolute.

gt is for evaluating un-hanced baseline experiment, 