### PR TITLE
fix import error for FileReader and PILImageLoader

### DIFF
--- a/vision_datasets/commands/converter_to_aml_coco.py
+++ b/vision_datasets/commands/converter_to_aml_coco.py
@@ -5,8 +5,8 @@ from urllib.parse import urlparse, urlunparse
 
 from tqdm import tqdm
 
-from vision_datasets.commands.utils import FileReader, PILImageLoader, add_args_to_locate_dataset, get_or_generate_data_reg_json_and_usages
-from vision_datasets.common import CocoDictGeneratorFactory, DatasetHub, DatasetTypes
+from vision_datasets.commands.utils import add_args_to_locate_dataset, get_or_generate_data_reg_json_and_usages
+from vision_datasets.common import FileReader, PILImageLoader, CocoDictGeneratorFactory, DatasetHub, DatasetTypes
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
After a recent refactor, FileReader and PILImageLoader are now under the vision_datasets.common package instead of the vision_datasets.commands.utils