### PR TITLE
open-vocab od to kvp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 from os import path
 
-VERSION = '1.0.17'
+VERSION = '1.0.18'
 
 # Get the long description from the README file
 here = path.abspath(path.dirname(__file__))

--- a/tests/test_coco_iris_to_kvp_wrapper/test_detection_as_kvp.py
+++ b/tests/test_coco_iris_to_kvp_wrapper/test_detection_as_kvp.py
@@ -2,7 +2,10 @@ import unittest
 
 from tests.test_fixtures import DetectionTestFixtures
 from vision_datasets.common.constants import DatasetTypes
-from vision_datasets.image_object_detection import DetectionAsKeyValuePairDataset, DetectionAsKeyValuePairDatasetForMultilabelClassification
+from vision_datasets.image_object_detection import (
+    DetectionAsKeyValuePairDataset,
+    DetectionAsKeyValuePairDatasetForMultilabelClassification,
+)
 from vision_datasets.key_value_pair.manifest import KeyValuePairLabelManifest
 
 
@@ -18,62 +21,181 @@ class TestDetectionAsKeyValuePairDataset(unittest.TestCase):
             self.assertIn("description", kvp_dataset.dataset_info.schema)
             self.assertIn("fieldSchema", kvp_dataset.dataset_info.schema)
 
-            self.assertEqual(kvp_dataset.dataset_info.schema["fieldSchema"],
-                            {'detectedObjects': {'type': 'array', 'description': 'Objects in the image of the specified classes, with bounding boxes',
-                                                'items': {'type': 'string', 'description': 'Class name of the object',
-                                                            'classes': {'1-class': {},
-                                                                        '2-class': {},
-                                                                        '3-class': {},
-                                                                        '4-class': {}},
-                                                            'includeGrounding': True}}})
+            self.assertEqual(
+                kvp_dataset.dataset_info.schema["fieldSchema"],
+                {
+                    "detectedObjects": {
+                        "type": "array",
+                        "description": "Objects in the image of the specified classes, with bounding boxes",
+                        "items": {
+                            "type": "string",
+                            "description": "Class name of the object",
+                            "classes": {
+                                "1-class": {},
+                                "2-class": {},
+                                "3-class": {},
+                                "4-class": {},
+                            },
+                            "includeGrounding": True,
+                        },
+                    }
+                },
+            )
 
             _, target, _ = kvp_dataset[0]
             self.assertIsInstance(target, KeyValuePairLabelManifest)
-            self.assertEqual(target.label_data,
-                            {'fields': {'detectedObjects': {'value': [{'value': '1-class', 'groundings': [[0, 0, 100, 100]]},
-                                                                    {'value': '2-class', 'groundings': [[10, 10, 50, 100]]}]}}
-                            })
+            self.assertEqual(
+                target.label_data,
+                {
+                    "fields": {
+                        "detectedObjects": {
+                            "value": [
+                                {"value": "1-class", "groundings": [[0, 0, 100, 100]]},
+                                {"value": "2-class", "groundings": [[10, 10, 50, 100]]},
+                            ]
+                        }
+                    }
+                },
+            )
 
     def test_single_class_description(self):
-        sample_detection_dataset, tempdir = DetectionTestFixtures.create_an_od_dataset(n_categories=1)
+        sample_detection_dataset, tempdir = DetectionTestFixtures.create_an_od_dataset(
+            n_categories=1
+        )
         with tempdir:
             kvp_dataset = DetectionAsKeyValuePairDataset(sample_detection_dataset)
 
-            self.assertEqual(kvp_dataset.dataset_info.schema["fieldSchema"]['detectedObjects']['items']['classes'],
-                            {'1-class': {"description": "Always output 1-class as the class."}})
+            self.assertEqual(
+                kvp_dataset.dataset_info.schema["fieldSchema"]["detectedObjects"][
+                    "items"
+                ]["classes"],
+                {"1-class": {"description": "Always output 1-class as the class."}},
+            )
+
+    def test_do_not_include_class_names(self):
+        sample_detection_dataset, tempdir = DetectionTestFixtures.create_an_od_dataset()
+        with tempdir:
+            kvp_dataset = DetectionAsKeyValuePairDataset(
+                sample_detection_dataset, include_class_names=False
+            )
+
+            self.assertIsInstance(kvp_dataset, DetectionAsKeyValuePairDataset)
+            self.assertEqual(
+                kvp_dataset.dataset_info.schema["fieldSchema"],
+                {
+                    "detectedObjects": {
+                        "type": "array",
+                        "description": "Objects in the image of the specified classes, with bounding boxes",
+                        "items": {
+                            "type": "string",
+                            "description": "Class name of the object",
+                            "includeGrounding": True,
+                        },
+                    }
+                },
+            )
+    
+    def test_custom_schema_description(self):
+        sample_detection_dataset, tempdir = DetectionTestFixtures.create_an_od_dataset()
+        with tempdir:
+            kvp_dataset = DetectionAsKeyValuePairDataset(
+                sample_detection_dataset, custom_schema_description="Custom description"
+            )
+
+            self.assertIsInstance(kvp_dataset, DetectionAsKeyValuePairDataset)
+            self.assertEqual(
+                kvp_dataset.dataset_info.schema["description"], "Custom description"
+            )
+
 
 
 class TestDetectionAsKeyValuePairDatasetForMultilabelClassification(unittest.TestCase):
     def test_detection_to_kvp(self):
         sample_detection_dataset, tempdir = DetectionTestFixtures.create_an_od_dataset()
         with tempdir:
-            kvp_dataset = DetectionAsKeyValuePairDatasetForMultilabelClassification(sample_detection_dataset)
+            kvp_dataset = DetectionAsKeyValuePairDatasetForMultilabelClassification(
+                sample_detection_dataset
+            )
 
-            self.assertIsInstance(kvp_dataset, DetectionAsKeyValuePairDatasetForMultilabelClassification)
+            self.assertIsInstance(
+                kvp_dataset, DetectionAsKeyValuePairDatasetForMultilabelClassification
+            )
             self.assertEqual(kvp_dataset.dataset_info.type, DatasetTypes.KEY_VALUE_PAIR)
             self.assertIn("name", kvp_dataset.dataset_info.schema)
             self.assertIn("description", kvp_dataset.dataset_info.schema)
             self.assertIn("fieldSchema", kvp_dataset.dataset_info.schema)
 
             print(kvp_dataset.dataset_info.schema["fieldSchema"])
-            self.assertEqual(kvp_dataset.dataset_info.schema["fieldSchema"],
-                            {'objectClassNames': {
-                                'type': 'array', 
-                                'description': 'Unique class names of objects in the image of the specified classes.', 
-                                'items': {
-                                    'type': 'string', 
-                                    'description': 'Class name of the object.',
-                                    'classes': {'1-class': {}, '2-class': {}, '3-class': {}, '4-class': {}}}}}
+            self.assertEqual(
+                kvp_dataset.dataset_info.schema["fieldSchema"],
+                {
+                    "objectClassNames": {
+                        "type": "array",
+                        "description": "Unique class names of objects in the image of the specified classes.",
+                        "items": {
+                            "type": "string",
+                            "description": "Class name of the object.",
+                            "classes": {
+                                "1-class": {},
+                                "2-class": {},
+                                "3-class": {},
+                                "4-class": {},
+                            },
+                        },
+                    }
+                },
             )
             _, target, _ = kvp_dataset[0]
             print(target.label_data)
             self.assertIsInstance(target, KeyValuePairLabelManifest)
-            self.assertEqual(target.label_data,
-                            {'fields': {
-                                'objectClassNames': {
-                                    'value': [{'value': '1-class'}, {'value': '2-class'}]}}}
-                            )
+            self.assertEqual(
+                target.label_data,
+                {
+                    "fields": {
+                        "objectClassNames": {
+                            "value": [{"value": "1-class"}, {"value": "2-class"}]
+                        }
+                    }
+                },
+            )
+
+    def test_do_not_include_class_names(self):
+        sample_detection_dataset, tempdir = DetectionTestFixtures.create_an_od_dataset()
+        with tempdir:
+            kvp_dataset = kvp_dataset = (
+                DetectionAsKeyValuePairDatasetForMultilabelClassification(
+                    sample_detection_dataset, include_class_names=False
+                )
+            )
+
+            self.assertIsInstance(
+                kvp_dataset, DetectionAsKeyValuePairDatasetForMultilabelClassification
+            )
+            self.assertEqual(
+                kvp_dataset.dataset_info.schema["fieldSchema"],
+                {
+                    "objectClassNames": {
+                        "type": "array",
+                        "description": "Unique class names of objects in the image of the specified classes.",
+                        "items": {
+                            "type": "string",
+                            "description": "Class name of the object.",
+                        },
+                    }
+                },
+            )
+    def test_custom_schema_description(self):
+        sample_detection_dataset, tempdir = DetectionTestFixtures.create_an_od_dataset()
+        with tempdir:
+            kvp_dataset = DetectionAsKeyValuePairDatasetForMultilabelClassification(
+                sample_detection_dataset, custom_schema_description="Custom description"
+            )
+
+            self.assertIsInstance(kvp_dataset, DetectionAsKeyValuePairDatasetForMultilabelClassification)
+            self.assertEqual(
+                kvp_dataset.dataset_info.schema["description"], "Custom description"
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/vision_datasets/image_object_detection/detection_as_kvp_dataset.py
+++ b/vision_datasets/image_object_detection/detection_as_kvp_dataset.py
@@ -24,7 +24,7 @@ class DetectionAsKeyValuePairDatasetBase(VisionDataset):
         Initializes an instance of the DetectionAsKeyValuePairDataset class.
         Args:
             detection_dataset (VisionDataset): The detection dataset to convert to key-value pair dataset.
-            include_class_nams (bool): If True, include class names in the schema. If False, exclude class names in the schema. When class names are excluded, the task becomes open-vocabulary and the model can output any class name.
+            include_class_nams (bool): If True, include class names in the schema. When class names are excluded, the task becomes open-vocabulary. 
             custom_schema_description (str): Custom description for the schema. If None, the default description is used.
         """
 

--- a/vision_datasets/image_object_detection/detection_as_kvp_dataset.py
+++ b/vision_datasets/image_object_detection/detection_as_kvp_dataset.py
@@ -82,18 +82,18 @@ class DetectionAsKeyValuePairDatasetBase(VisionDataset):
         )
 
     def construct_schema(
-        self, include_class_names: bool, custom_schema_description: Union[str, None]
+        self, include_class_names: bool, custom_schema_description: Optional[str]
     ) -> Dict[str, Any]:
         schema: Dict[str, Any] = self.DETECTION_SCHEMA  # initialize with base schema
         if include_class_names:
-            schema["fieldSchema"][f"{self.OBJECTS_KEY}"]["items"]["classes"] = {
+            schema["fieldSchema"][self.OBJECTS_KEY]["items"]["classes"] = {
                 c: {"description": f"Always output {c} as the class."}
                 if len(self.class_names) == 1
                 else {}
                 for c in self.class_names
             }
         else:
-            del schema["fieldSchema"][f"{self.OBJECTS_KEY}"]["items"]["classes"]
+            del schema["fieldSchema"][self.OBJECTS_KEY]["items"]["classes"]
 
         if custom_schema_description is not None:
             schema["description"] = custom_schema_description
@@ -101,7 +101,7 @@ class DetectionAsKeyValuePairDatasetBase(VisionDataset):
         return schema
 
     def construct_kvp_label_data(self, bboxes: List[List[int]]):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def sort_bboxes_label_wise(
         self, bboxes: List[List[int]]
@@ -152,12 +152,12 @@ class DetectionAsKeyValuePairDataset(DetectionAsKeyValuePairDatasetBase):
         label_wise_bboxes = self.sort_bboxes_label_wise(bboxes)
 
         return {
-            f"{KeyValuePairLabelManifest.LABEL_KEY}": {
-                f"{self.OBJECTS_KEY}": {
-                    f"{KeyValuePairLabelManifest.LABEL_VALUE_KEY}": [
+            KeyValuePairLabelManifest.LABEL_KEY: {
+                self.OBJECTS_KEY: {
+                    KeyValuePairLabelManifest.LABEL_VALUE_KEY: [
                         {
-                            f"{KeyValuePairLabelManifest.LABEL_VALUE_KEY}": key,
-                            f"{KeyValuePairLabelManifest.LABEL_GROUNDINGS_KEY}": value,
+                            KeyValuePairLabelManifest.LABEL_VALUE_KEY: key,
+                            KeyValuePairLabelManifest.LABEL_GROUNDINGS_KEY: value,
                         }
                         for key, value in label_wise_bboxes.items()
                     ]
@@ -195,10 +195,10 @@ class DetectionAsKeyValuePairDatasetForMultilabelClassification(
         label_wise_bboxes = self.sort_bboxes_label_wise(bboxes)
 
         return {
-            f"{KeyValuePairLabelManifest.LABEL_KEY}": {
-                f"{self.OBJECTS_KEY}": {
-                    f"{KeyValuePairLabelManifest.LABEL_VALUE_KEY}": [
-                        {f"{KeyValuePairLabelManifest.LABEL_VALUE_KEY}": key}
+            KeyValuePairLabelManifest.LABEL_KEY: {
+                self.OBJECTS_KEY: {
+                    KeyValuePairLabelManifest.LABEL_VALUE_KEY: [
+                        {KeyValuePairLabelManifest.LABEL_VALUE_KEY: key}
                         for key in label_wise_bboxes.keys()
                     ]
                 }

--- a/vision_datasets/image_object_detection/detection_as_kvp_dataset.py
+++ b/vision_datasets/image_object_detection/detection_as_kvp_dataset.py
@@ -1,6 +1,6 @@
 import logging
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from vision_datasets.common import DatasetTypes, KeyValuePairDatasetInfo, VisionDataset
 from vision_datasets.key_value_pair import (
@@ -82,7 +82,7 @@ class DetectionAsKeyValuePairDatasetBase(VisionDataset):
         )
 
     def construct_schema(
-        self, include_class_names: bool, custom_schema_description: str | None
+        self, include_class_names: bool, custom_schema_description: Union[str, None]
     ) -> Dict[str, Any]:
         schema: Dict[str, Any] = self.DETECTION_SCHEMA  # initialize with base schema
         if include_class_names:


### PR DESCRIPTION
This PR updates the OD to KVP adapter by adding two functionalities:
1. It accepts a bool flag to include/exclude class names in the schema
2. It accepts a custom description to be used in the schema (especially useful for the case when class names are not provided. The custom description can help provide the necessary context to the model.)